### PR TITLE
Initial multi-monitor support

### DIFF
--- a/screen_ocr/_screen_ocr.py
+++ b/screen_ocr/_screen_ocr.py
@@ -1,6 +1,7 @@
 """Library for processing screen contents using OCR."""
 
 import numpy as np
+from mss import mss
 from PIL import Image, ImageDraw, ImageGrab, ImageOps
 from rapidfuzz import fuzz
 from skimage import filters, morphology, transform
@@ -140,7 +141,6 @@ class Reader(object):
     def _screenshot_nearby(self, screen_coordinates, monitor):
         # TODO Consider cropping within grab() for performance. Requires knowledge
         # of screen bounds.
-        from mss import mss
         with mss() as sct:
             monitor = sct.monitors[monitor]
             sct_img = sct.grab(monitor)


### PR DESCRIPTION
This PR utilizes mss to screenshot screens. This should add a small speed boost compared to ImageGrab.grab for capturing the screenshot. [mss](https://pypi.org/project/mss/) is cross-platform but limited to Python 3.5 and above.

There's a few the reasons why I consider this draft.
- I might include Python 2.7 support.
- You might want to have the monitor argument placed differently? We need to keep in mind that the monitor might change depending on the user.
- There is an issue running out of memory when taking a 4K monitor screenshot which the function below reproduces with a `radius=3000` most directly related to using a 32-bit Python interpreter or the list might might have too many items. This issue is reproducible with `ImageGrab.grab(all_screens=True)` and `mss`. `gc.collect()` does not seem having an impact on the issue.


```python
def run_ocr(radius, start_coordinates):
    import timeit
    import screen_ocr

    ocr_reader = screen_ocr.Reader(backend="winrt").create_quality_reader(radius=radius)
    start_time = timeit.default_timer()
    screencontents = ocr_reader.read_nearby(start_coordinates, monitor=2)
    end_time = ("{0:.3f}".format(timeit.default_timer() - start_time))
    print("radius-{}_time-{}".format(radius, end_time)) # Debug

print(run_ocr(radius=3000, start_coordinates=(0,0)))
```

```
Traceback (most recent call last):
  File "c:\Users\Main\CodeShare\Laptop\ocr_scaling_test\tempCodeRunnerFile.python", line 11, in <module>
    print(run_ocr(radius=3000, start_coordinates=(0,0)))
  File "c:\Users\Main\CodeShare\Laptop\ocr_scaling_test\tempCodeRunnerFile.python", line 7, in run_ocr
    screencontents = ocr_reader.read_nearby(start_coordinates, monitor=2)
  File "d:\backup\library\documents\screen-ocr\screen_ocr\_screen_ocr.py", line 125, in read_nearby
    return self.read_image(screenshot,
  File "d:\backup\library\documents\screen-ocr\screen_ocr\_screen_ocr.py", line 132, in read_image
    result = self._backend.run_ocr(preprocessed_image)
  File "d:\backup\library\documents\screen-ocr\screen_ocr\_winrt.py", line 15, in run_ocr
    return self._executor.submit(lambda: self._run_ocr_sync(image)).result()
  File "C:\Users\Main\AppData\Local\Programs\Python\Python38-32\lib\concurrent\futures\_base.py", line 439, in result
    return self.__get_result()
  File "C:\Users\Main\AppData\Local\Programs\Python\Python38-32\lib\concurrent\futures\_base.py", line 388, in __get_result
    raise self._exception
  File "C:\Users\Main\AppData\Local\Programs\Python\Python38-32\lib\concurrent\futures\thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "d:\backup\library\documents\screen-ocr\screen_ocr\_winrt.py", line 15, in <lambda>
    return self._executor.submit(lambda: self._run_ocr_sync(image)).result()
  File "d:\backup\library\documents\screen-ocr\screen_ocr\_winrt.py", line 47, in _run_ocr_sync
    return asyncio.run(self._run_ocr_async(image))
  File "C:\Users\Main\AppData\Local\Programs\Python\Python38-32\lib\asyncio\runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "C:\Users\Main\AppData\Local\Programs\Python\Python38-32\lib\asyncio\base_events.py", line 616, in run_until_complete
    return future.result()
  File "d:\backup\library\documents\screen-ocr\screen_ocr\_winrt.py", line 26, in run_ocr_async
    bytes_list = list(bytes)
MemoryError
```