### PR TITLE
Possability to define one language to recognize

### DIFF
--- a/screen_ocr/_screen_ocr.py
+++ b/screen_ocr/_screen_ocr.py
@@ -99,6 +99,7 @@ class Reader:
         convert_grayscale=True,
         shift_channels=True,
         debug_image_callback=None,
+        language_tag=None,
         **kwargs,
     ) -> "Reader":
         """Create reader with specified backend."""

--- a/screen_ocr/_screen_ocr.py
+++ b/screen_ocr/_screen_ocr.py
@@ -142,7 +142,7 @@ class Reader:
                     "WinRT backend unavailable. To install, run pip install screen-ocr[winrt]."
                 )
             try:
-                backend = _winrt.WinRtBackend()
+                backend = _winrt.WinRtBackend(language_tag)
             except ImportError:
                 raise ValueError(
                     "WinRT backend unavailable. To install, run pip install screen-ocr[winrt]."

--- a/screen_ocr/_winrt.py
+++ b/screen_ocr/_winrt.py
@@ -31,7 +31,6 @@ class WinRtBackend(_base.OcrBackend):
             for language in ocr.OcrEngine.get_available_recognizer_languages():
                 if language.language_tag == language_tag:
                     engine = ocr.OcrEngine.try_create_from_language(language)
-                    print(f'CREATED {engine} with {language_tag}')
                     break
 
         if not engine:

--- a/screen_ocr/_winrt.py
+++ b/screen_ocr/_winrt.py
@@ -11,20 +11,29 @@ if not importlib.util.find_spec("winrt"):
 
 
 class WinRtBackend(_base.OcrBackend):
-    def __init__(self):
+    def __init__(self, language_tag: str=None):
         # Run all winrt interactions on a new thread to avoid
         # "RuntimeError: Cannot change thread mode after it is set."
         # from import winrt.
         self._executor = futures.ThreadPoolExecutor(max_workers=1)
-        self._executor.submit(self._init_winrt).result()
+        self._executor.submit(self._init_winrt, language_tag).result()
 
-    def _init_winrt(self):
+    def _init_winrt(self, language_tag):
         import winrt
         import winrt.windows.graphics.imaging as imaging
         import winrt.windows.media.ocr as ocr
         import winrt.windows.storage.streams as streams
 
-        engine = ocr.OcrEngine.try_create_from_user_profile_languages()
+        engine = None
+        if language_tag is None:
+            engine = ocr.OcrEngine.try_create_from_user_profile_languages()
+        else:            
+            for language in ocr.OcrEngine.get_available_recognizer_languages():
+                if language.language_tag == language_tag:
+                    engine = ocr.OcrEngine.try_create_from_language(language)
+                    print(f'CREATED {engine} with {language_tag}')
+                    break
+
         if not engine:
             raise RuntimeError(
                 "Could not create OcrEngine. Try installing language packs: "


### PR DESCRIPTION
Currently framework uses all available languages installed in order to recognize text, in such case result may contain mix of latters from different languages in single word/sentence. This feature allows to select single language.